### PR TITLE
vgg has attribute 'cfgs' and not just 'cfg'

### DIFF
--- a/cycada/models/fcn8s.py
+++ b/cycada/models/fcn8s.py
@@ -56,7 +56,7 @@ class VGG16_FCN8s(nn.Module):
 			batch_norm = False
 		else:
 			batch_norm = True
-		self.vgg = make_layers(vgg.cfg['D'], batch_norm=False)
+		self.vgg = make_layers(vgg.cfgs['D'], batch_norm=False)
 		self.vgg_head = nn.Sequential(
 			nn.Conv2d(512, 4096, 7),
 			nn.ReLU(inplace=True),


### PR DESCRIPTION
solves error: AttributeError: module 'torchvision.models.vgg' has no attribute 'cfg'